### PR TITLE
Version bump

### DIFF
--- a/lib/octopus/version.rb
+++ b/lib/octopus/version.rb
@@ -1,3 +1,3 @@
 module Octopus
-  VERSION = '0.10.2'
+  VERSION = '0.10.3'
 end


### PR DESCRIPTION
a39612969286891c705384c214d7f1d0c365609f contains a fix for rails 6, we just need to bump the version so we can pull it in